### PR TITLE
Update pack.mcmeta version to follow post 25w31a format

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -2,6 +2,8 @@
   "pack": {
     "description": "${modid} resources",
     "pack_format": 15,
-    "supported_formats": [15, 999999]
+    "supported_formats": [15, 999999],
+    "min_format": 64,
+    "max_format": 999999
   }
 }


### PR DESCRIPTION
Fix https://github.com/Enchanted-Games/stop-unloading-my-shaders/issues/5 .

[25w31a](https://minecraft.wiki/w/Java_Edition_25w31a) has changed the way the version in `pack.mcmeta` is handled. Adds the new format, which removes the error mentioned in the above issue.